### PR TITLE
hyperde3 and ichan2: drop INITIAL return values

### DIFF
--- a/README.html
+++ b/README.html
@@ -100,5 +100,6 @@ Changelog
   case anyone wants to do that.
 * 20220924: Update MOD files to avoid declaring variables and functions
             with the same name. See https://github.com/neuronsimulator/nrn/pull/1992
+* 20221124: hyperde3 and ichan2: drop INITIAL return values, just return
 
 </pre></html>

--- a/hyperde3.mod
+++ b/hyperde3.mod
@@ -103,7 +103,7 @@ INITIAL {
 	hyhtf = hyhtfinf
 	hyhts = hyhtsinf
 	VERBATIM
-	return 0;
+	return;
 	ENDVERBATIM
 }
 

--- a/ichan2.mod
+++ b/ichan2.mod
@@ -91,7 +91,7 @@ INITIAL {
       ns = nsinf
 	
 	VERBATIM
-	return 0;
+	return;
 	ENDVERBATIM
 }
 


### PR DESCRIPTION
On my M1 I get
```
hyperde3.cpp:578:2: error: void function 'initmodel' should not return a value [-Wreturn-type]
        return 0;
        ^      ~
1 error generated.
make: *** [hyperde3.o] Error 1
make: *** Waiting for unfinished jobs....
ichan2.cpp:579:2: error: void function 'initmodel' should not return a value [-Wreturn-type]
        return 0;
        ^      ~
1 error generated.
```
